### PR TITLE
Hidden panes fix for IE11

### DIFF
--- a/projects/angular-split/src/lib/component/split.component.scss
+++ b/projects/angular-split/src/lib/component/split.component.scss
@@ -33,7 +33,7 @@
         /* When <as-split-area [visible]="false"> force size to 0. */
 
         &.as-hidden {
-            flex: 0 1 0 !important;
+            flex: 0 1 0px !important;
             overflow-x: hidden;
             overflow-y: hidden;
         }


### PR DESCRIPTION
`flex-basis 0` is not recognized by IE11. Adding `px` unit fixes the problem.